### PR TITLE
Support 128-bit integers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 rust-separator
 ==============
 
-Formats numbers into strings with thousands separators for readability. It currently supports floating-points (`f32` and `f64`), unsigned integers (`u16`, `u32`, and `u64`), signed integers (`i16`, `i32`, `i64`), and size types (`isize` and `usize`).
+Formats numbers into strings with thousands separators for readability. It currently supports floating-points (`f32` and `f64`), unsigned integers (`u16`, `u32`, `u64`, `u128`), signed integers (`i16`, `i32`, `i64`, `i128`), and size types (`isize` and `usize`).
 
 Usage
 -----

--- a/src/signed_int.rs
+++ b/src/signed_int.rs
@@ -20,3 +20,10 @@ impl Separatable for i64 {
         separated_int!(string)
     }
 }
+
+impl Separatable for i128 {
+    fn separated_string(&self) -> String {
+        let string = format!("{}", self);
+        separated_int!(string)
+    }
+}

--- a/src/unsigned_int.rs
+++ b/src/unsigned_int.rs
@@ -20,3 +20,10 @@ impl Separatable for u64 {
         separated_uint!(string)
     }
 }
+
+impl Separatable for u128 {
+    fn separated_string(&self) -> String {
+        let string = format!("{}", self);
+        separated_uint!(string)
+    }
+}

--- a/tests/signed_int/i128/mod.rs
+++ b/tests/signed_int/i128/mod.rs
@@ -1,0 +1,109 @@
+use separator::Separatable;
+
+#[test]
+fn negative_nine_hundred_million() {
+    let i : i128 = -900000000;
+    assert_eq!("-900,000,000", &i.separated_string());
+}
+
+#[test]
+fn negative_ninety_million() {
+    let i : i128 = -90000000;
+    assert_eq!("-90,000,000", &i.separated_string());
+}
+
+#[test]
+fn negative_nine_million() {
+    let i : i128 = -9000000;
+    assert_eq!("-9,000,000", &i.separated_string());
+}
+
+#[test]
+fn negative_nine_hundred_thousand() {
+    let i : i128 = -900000;
+    assert_eq!("-900,000", &i.separated_string());
+}
+
+#[test]
+fn negative_ninety_thousand() {
+    let i : i128 = -90000;
+    assert_eq!("-90,000", &i.separated_string());
+}
+
+#[test]
+fn negative_nine_thousand() {
+    let i : i128 = -9000;
+    assert_eq!("-9,000", &i.separated_string());
+}
+
+#[test]
+fn negative_nine_hundred() {
+    let i : i128 = -900;
+    assert_eq!("-900", &i.separated_string());
+}
+
+#[test]
+fn negative_ninety() {
+    let i : i128 = -90;
+    assert_eq!("-90", &i.separated_string());
+}
+
+#[test]
+fn negative_nine() {
+    let i : i128 = -9;
+    assert_eq!("-9", &i.separated_string());
+}
+
+#[test]
+fn nine() {
+    let i : i128 = 9;
+    assert_eq!("9", &i.separated_string());
+}
+
+#[test]
+fn ninety() {
+    let i : i128 = 90;
+    assert_eq!("90", &i.separated_string());
+}
+
+#[test]
+fn nine_hundred() {
+    let i : i128 = 900;
+    assert_eq!("900", &i.separated_string());
+}
+
+#[test]
+fn nine_thousand() {
+    let i : i128 = 9000;
+    assert_eq!("9,000", &i.separated_string());
+}
+
+#[test]
+fn ninety_thousand() {
+    let i : i128 = 90000;
+    assert_eq!("90,000", &i.separated_string());
+}
+
+#[test]
+fn nine_hundred_thousand() {
+    let i : i128 = 900000;
+    assert_eq!("900,000", &i.separated_string());
+}
+
+#[test]
+fn nine_million() {
+    let i : i128 = 9000000;
+    assert_eq!("9,000,000", &i.separated_string());
+}
+
+#[test]
+fn ninety_million() {
+    let i : i128 = 90000000;
+    assert_eq!("90,000,000", &i.separated_string());
+}
+
+#[test]
+fn nine_hundred_million() {
+    let i : i128 = 900000000;
+    assert_eq!("900,000,000", &i.separated_string());
+}

--- a/tests/signed_int/mod.rs
+++ b/tests/signed_int/mod.rs
@@ -1,3 +1,4 @@
 mod i16;
 mod i32;
 mod i64;
+mod i128;

--- a/tests/unsigned_int/mod.rs
+++ b/tests/unsigned_int/mod.rs
@@ -1,3 +1,4 @@
 mod u16;
 mod u32;
 mod u64;
+mod u128;

--- a/tests/unsigned_int/u128/mod.rs
+++ b/tests/unsigned_int/u128/mod.rs
@@ -1,0 +1,55 @@
+use separator::Separatable;
+
+#[test]
+fn nine() {
+    let i : u128 = 9;
+    assert_eq!("9", &i.separated_string());
+}
+
+#[test]
+fn ninety() {
+    let i : u128 = 90;
+    assert_eq!("90", &i.separated_string());
+}
+
+#[test]
+fn nine_hundred() {
+    let i : u128 = 900;
+    assert_eq!("900", &i.separated_string());
+}
+
+#[test]
+fn nine_thousand() {
+    let i : u128 = 9000;
+    assert_eq!("9,000", &i.separated_string());
+}
+
+#[test]
+fn ninety_thousand() {
+    let i : u128 = 90000;
+    assert_eq!("90,000", &i.separated_string());
+}
+
+#[test]
+fn nine_hundred_thousand() {
+    let i : u128 = 900000;
+    assert_eq!("900,000", &i.separated_string());
+}
+
+#[test]
+fn nine_million() {
+    let i : u128 = 9000000;
+    assert_eq!("9,000,000", &i.separated_string());
+}
+
+#[test]
+fn ninety_million() {
+    let i : u128 = 90000000;
+    assert_eq!("90,000,000", &i.separated_string());
+}
+
+#[test]
+fn nine_hundred_million() {
+    let i : u128 = 900000000;
+    assert_eq!("900,000,000", &i.separated_string());
+}


### PR DESCRIPTION
`i128`/`u128` have been [stable since Rust 1.26.0](https://doc.rust-lang.org/nightly/std/primitive.i128.html).

If you want to keep support for older compilers I can add a feature flag to enable this support.