### PR TITLE
Support formatting custom types: export separated_uint_with_output!()

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,4 @@
+#[macro_export]
 macro_rules! separated_uint_with_output {
     ($string:expr, $output:expr) => {{
         let mut place = $string.len();

--- a/tests/custom.rs
+++ b/tests/custom.rs
@@ -1,0 +1,17 @@
+#[macro_use] extern crate separator;
+use separator::Separatable;
+
+struct CustomNum(u32);
+
+impl Separatable for CustomNum {
+    fn separated_string(&self) -> String {
+        let string = format!("{}", self.0);
+        separated_uint!(string)
+    }
+}
+
+#[test]
+fn nine_hundred_million() {
+    let i = CustomNum(900000000);
+    assert_eq!("900,000,000", &i.separated_string());
+}


### PR DESCRIPTION
I tried to use your crate with the num-bigint crate and hit a problem where the compiler wanted another macro exported. When I did that, it worked great! Thanks!

Nothing urgent here. This was some local playing around.

I added a test outside of your collection of tests, so that the custom test could include macros while leaving your tests without macro import.